### PR TITLE
remove pause and resume seems to fix error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ var plugin = module.exports = function (options) {
 
   function notify (file, enc, callback) {
     var stream = this;
-    stream.pause();
 
     report(reporter, file, options, templateOptions, function (err) {
       if (err) {
@@ -23,7 +22,6 @@ var plugin = module.exports = function (options) {
       } else {
         stream.push(file);
       }
-      stream.resume();
       callback();
     });
   }


### PR DESCRIPTION
I also ran into #4. I know next to nothing about node streams, but after reading this http://stackoverflow.com/questions/18306954/cannot-switch-to-old-mode-now-node-js-apn-module-error-in-tls-connect-functi I figured I would try removing the pause/resume, which _seems_ to have solved the problem. No idea if this is even a good idea, but for me everything seems to work as expected :)
