### PR TITLE
only call reporter if there is a message to report

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,10 @@ function report (reporter, message, options, templateOptions, callback) {
 
   // Try/catch the only way to go to ensure catching all errors? Domains?
   try {
-    reporter(constructOptions(options, message, templateOptions), function (err) {
+    var reporterOptions = constructOptions(options, message, templateOptions);
+    if(!reporterOptions.message) return callback();
+
+    reporter(reporterOptions, function (err) {
       if (err) return callback(new gutil.PluginError("gulp-notify", err));
       return callback();
     });


### PR DESCRIPTION
I am using gulp-notify to give notifications from gulp-jshint, which will add information about a run to the file object. With the `notify(Function)` syntax, I am able to build up a short message and display it, which works very well.

The problem is that when there is no errors to report, a notification still pops up. I can't really think of a use case where you would want to report nothing, so this basically just adds a check to see if there is a message before invoking the reporter. 

If there is a use case I am not thinking of, I still think that returning undefined from the function should indicate that you don't want the reporter to run. If you like, I can modify the PR to only do that. 
