### PR TITLE
keep extra options (for other reporter)

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -31,6 +31,10 @@ function constructOptions (options, object, templateOptions) {
     message = options(object);
   }
 
+  if (typeof options === "string") {
+    message = options;
+  }
+
   if (typeof options === "object") {
     if (typeof options.title === "function") {
       title = options.title(object);
@@ -43,35 +47,31 @@ function constructOptions (options, object, templateOptions) {
     } else {
       message = options.message || message;
     }
-  }
-
-  if (typeof options === "string") {
-    message = options;
+  } else {
+    options = {};
   }
 
   if (object instanceof Error) {
     var titleTemplate = template(title);
     var messageTemplate = template(message);
-    return {
-      title: titleTemplate({
-        error: object,
-        options: templateOptions
-      }),
-      message: messageTemplate({
-        error: object,
-        options: templateOptions
-      })
-    };
+    options.title = titleTemplate({
+      error: object,
+      options: templateOptions
+    });
+    options.message = messageTemplate({
+      error: object,
+      options: templateOptions
+    });
+  } else {
+    options.title = gutil.template(title, {
+      file: object,
+      options: templateOptions
+    });
+    options.message = gutil.template(message, {
+      file: object,
+      options: templateOptions
+    });
   }
-
-  return {
-    title: gutil.template(title, {
-      file: object,
-      options: templateOptions
-    }),
-    message: gutil.template(message, {
-      file: object,
-      options: templateOptions
-    })
-  };
+  
+  return options;
 }

--- a/test/main.js
+++ b/test/main.js
@@ -76,6 +76,37 @@ describe('gulp output stream', function() {
       instream.pipe(outstream);
     });
 
+    it('should call notifier with extra options untouched', function(done) {
+      var testString = "this is a test";
+      var testIcon = "face-cool";
+
+      var mockedNotify = notify.withReporter(mockGenerator(function (opts) {
+        should.exist(opts);
+        should.exist(opts.icon);
+        should.exist(opts.message);
+        String(opts.icon).should.equal(testIcon);
+        String(opts.message).should.equal(testString);
+      }));
+
+      var instream = gulp.src(join(__dirname, "./fixtures/*.txt")),
+          outstream = mockedNotify({
+            message: testString,
+            icon: testIcon
+          });
+
+      outstream.on('data', function(file) {
+        should.exist(file);
+        should.exist(file.path);
+        should.exist(file.contents);
+      });
+
+      outstream.on('end', function() {
+        done();
+      });
+
+      instream.pipe(outstream);
+    });
+
     it('should emit error when sub-module returns error', function(done) {
       var mockedNotify = notify.withReporter(function (options, callback) {
         callback(new Error(testString));


### PR DESCRIPTION
other reporter may have more options, I suggest to keep extras options and pass them to the reporter

use case, with https://github.com/bnoguchi/node-notify-send, I can add timeout, priority and icon options. eg:

``` javascript
var notifier = notify.withReporter(function(options, callback) {
    growl.icon(options.icon).notify(options.title, options.message);
    callback();
});
```
