### PR TITLE
add templating power to subtitle and open

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -38,10 +38,12 @@ module.exports = function (reporter, message, options, templateOptions, callback
   }
 };
 
-function generate (outputData, object, title, message, templateOptions) {
+function generate (outputData, object, title, message, subtitle, open, templateOptions) {
   if (object instanceof Error) {
     var titleTemplate = template(title);
     var messageTemplate = template(message);
+    var openTemplate = template(open);
+    var subtitleTemplate = template(subtitle);
 
     return extend(defaults.error, outputData, {
       title: titleTemplate({
@@ -49,6 +51,14 @@ function generate (outputData, object, title, message, templateOptions) {
         options: templateOptions
       }),
       message: messageTemplate({
+        error: object,
+        options: templateOptions
+      }),
+      open: openTemplate({
+        error: object,
+        options: templateOptions
+      }),
+      subtitle: subtitleTemplate({
         error: object,
         options: templateOptions
       })
@@ -70,6 +80,8 @@ function generate (outputData, object, title, message, templateOptions) {
 function constructOptions (options, object, templateOptions) {
   var message = object.path || object.message || object,
       title = !(object instanceof Error) ? "Gulp notification" : "Error running Gulp",
+      open = "",
+      subtitle = "",
       outputData = {};
 
   if (typeof options === "function") {
@@ -90,7 +102,19 @@ function constructOptions (options, object, templateOptions) {
     } else {
       title = outputData.title || title;
     }
-
+    
+    if (typeof outputData.subtitle === "function") {
+      subtitle = outputData.subtitle(object);
+    } else {
+      subtitle = outputData.subtitle || subtitle;
+    }
+    
+    if (typeof outputData.open === "function") {
+      open = outputData.open(object);
+    } else {
+      open = outputData.open || open;
+    }
+    
     if (typeof outputData.message === "function") {
       message = outputData.message(object);
       if (!message) {
@@ -100,5 +124,5 @@ function constructOptions (options, object, templateOptions) {
       message = outputData.message || message;
     }
   }
-  return generate(outputData, object, title, message, templateOptions);
+  return generate(outputData, object, title, message, subtitle, open, templateOptions);
 }


### PR DESCRIPTION
only tested in OSX, extra useful with editor urls, like txmt:// or subl://
and getting useful subtiltes (available at least in the OSX notification center)