### PR TITLE
Fix titles never being used if called during write()

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -79,7 +79,7 @@ function generate (outputData, object, title, message, subtitle, open, templateO
 
 function constructOptions (options, object, templateOptions) {
   var message = object.path || object.message || object,
-      title = !(object instanceof Error) ? "Gulp notification" : "Error running Gulp",
+      title = object.title ? object.title : !(object instanceof Error) ? "Gulp notification" : "Error running Gulp",
       open = "",
       subtitle = "",
       outputData = {};


### PR DESCRIPTION
When calling using .write() gulp-notify does not carry over the `title` option.

For example:

    notify().write({
        title: 'Gulp: CSS',
        message: 'Error'
    });

Will currently carry over 'Error' as the title.