### PR TITLE
Prevent implicit highWaterMark option set by through.obj

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -44,11 +44,11 @@ module.exports = function (options) {
   }
 
   if (!options.onLast) {
-    return through.obj(notify);
+    return through({ objectMode: true }, notify);
   }
 
   // Only send notification on the last file.
-  return through.obj(function (file, enc, callback) {
+  return through({ objectMode: true }, function (file, enc, callback) {
     lastFile = file;
     this.push(file);
     callback();


### PR DESCRIPTION
`through.obj(...)` is documented as a shorthand for `through({ objectMode: true }, ...)` but in the source [through2.js:88](https://github.com/rvagg/through2/blob/master/through2.js#L88) it also sets the `highWaterMark` to 16. 

This appears to cause problems when there's more than 16 files and there's nothing consuming the stream (i.e. gulp-notify is the last plugin in the pipeline and the stream is not returned) - see gulpjs/gulp#716. I think it also accounts for issues #96, #94 and #83 here.

Not sure if the change in this pull request is correct - I don't know much about node streams to be honest, but it seemed to correct the problem on my machine. On the other hand, the [stream docs](https://nodejs.org/docs/v4.2.2/api/stream.html#stream_new_stream_readable_options) say `highWaterMark` has a default value of 16 anyway... so I don't know.

If there isn't an easy solution, maybe mention the need to consume the stream after notify() in the readme?
