### PR TITLE
Correct indent_style in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
The previous version uses `spaces` instead of [`space`](http://editorconfig.org/#file-format-details).