### PR TITLE
Update node-notifier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "gulp-util": "^3.0.2",
     "lodash.template": "^3.0.0",
-    "node-notifier": "^4.1.0",
+    "node-notifier": "^4.4.0",
     "node.extend": "^1.1.3",
     "through2": "^0.6.3"
   },


### PR DESCRIPTION
The package it fails for me on Windows 7 and Mac OS X El Capitan (newest update). Testing through the dependencies, this is the one that needs to be updated for it to work.