### PR TITLE
Upgrade lodash template function

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -1,4 +1,4 @@
-var template = require("lodash.template");
+var template = require("lodash/template");
 var PluginError = require('plugin-error');
 var api = require("./extra_api");
 var extend = require("node.extend");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "gulp-notify",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.2.0",
+      "name": "gulp-notify",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "fancy-log": "^1.3.3",
-        "lodash.template": "^4.5.0",
+        "lodash": "^4.17.21",
         "node-notifier": "^9.0.1",
         "node.extend": "^2.0.2",
         "plugin-error": "^1.0.1",
@@ -2381,27 +2382,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "node_modules/lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dependencies": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "node_modules/lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dependencies": {
-        "lodash._reinterpolate": "3.0.0"
-      }
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.0.0",
@@ -7223,27 +7208,10 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "requires": {
-        "lodash._reinterpolate": "3.0.0"
-      }
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "ansi-colors": "^4.1.1",
     "fancy-log": "^1.3.3",
-    "lodash.template": "^4.5.0",
+    "lodash": "^4.17.21",
     "node-notifier": "^9.0.1",
     "node.extend": "^2.0.2",
     "plugin-error": "^1.0.1",


### PR DESCRIPTION
[Usage of lodash's method packages is discouraged](https://lodash.com/per-method-packages) and the modules are not updated. ([source](https://github.com/lodash/lodash/issues/5882#issuecomment-2173987412))

Using gulp-notify will cause `npm audit` to fail since there is no updated version of `lodash.template`. The minimum amount of work is to just replace the method package with the `lodash/template` import.